### PR TITLE
use pangyp instead

### DIFF
--- a/build.js
+++ b/build.js
@@ -63,19 +63,19 @@ else {
 // Build it
 function build() {
 	cp.spawn(
-			process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp', ['rebuild'].concat(args), {
-				stdio: 'pipe'
+			process.platform === 'win32' ? 'pangyp.cmd' : 'pangyp', ['rebuild'].concat(args), {
+				stdio: 'inherit'
 			})
 		.on('exit', function(err) {
 			if (err) {
 				if (err === 127) {
 					console.error(
-						'node-gyp not found! Please upgrade your install of npm! You need at least 1.1.5 (I think) ' +
+						'pangyp not found! Please upgrade your install of npm! You need at least 1.1.5 (I think) ' +
 						'and preferably 1.1.30.'
 					);
 				}
 				else {
-					console.error('Build failed');
+					console.error('Build failed: ' + err);
 				}
 				return process.exit(err);
 			}


### PR DESCRIPTION
Using deasync on iojs currently fails because node-gyp has issue: https://github.com/TooTallNate/node-gyp/pull/564

It's taking a long time for this issue to be fixed, so here is a branch that uses pangyp instead, so that iojs can also have deasync.

Also: actually prints any errors that occur, because otherwise they were being eaten, and it was very difficult to debug.