### PR TITLE
Enable building on powerpc64 and powerpc(32).

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,7 +28,9 @@ var args = process.argv.slice(2).filter(function(arg) {
 if (!{
 		ia32: true,
 		x64: true,
-		arm: true
+		arm: true,
+		ppc64: true,
+		ppc: true
 	}.hasOwnProperty(arch)) {
 	console.error('Unsupported (?) architecture: `' + arch + '`');
 	process.exit(1);


### PR DESCRIPTION
Everything builds fine and the tests pass without error.

Signed-off-by: Daniel Axtens <dja@axtens.net>