### PR TITLE
Match tick callback to Node's logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,16 @@
 	});
 	
 	module.exports.runLoopOnce = function(){
-		process._tickDomainCallback();
+		var tick = process.domain
+			? process._tickDomainCallback
+			: process._tickCallback;
+		tick();
 		binding.run();
 	};
 	
 	module.exports.loopWhile = function(pred){
 	  while(pred()){
-		process._tickDomainCallback();
-		if(pred()) binding.run();
+		module.exports.runLoopOnce();
 	  }
 	};
 


### PR DESCRIPTION
Node calls the tick callback from two places: [`MakeCallback`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/src/node.cc#L1274) and [`AsyncWrap::MakeCallback`](https://github.com/nodejs/node/blob/f4fd073f0fc19da226de38eb595007bfee4c17d0/src/async-wrap.cc#L385).

Originally, I thought maybe `MakeCallback` could be used within `deasync.cc` to gain the same behavior with purely public APIs. My goal was to remove the the use of the private `_tick<?Domain>Callback`, but invocation of `tick_callback_function` is actually blocked because node will always be in a nested `AsyncCallbackScope` for both [`MakeCallback`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/src/node.cc#L1257) and [`AsyncWrap::MakeCallback`](https://github.com/nodejs/node/blob/f4fd073f0fc19da226de38eb595007bfee4c17d0/src/async-wrap.cc#L368). Initial code execution [begins in such a context](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/src/node.cc#L4368), and all future callbacks are done via subclasses of `AsyncWrap`, so their `MakeCallback` invocation always puts them back in an `AsyncCallbackScope`.

So since it wasn't possible to remove `_tick<?Domain>Callback`, I figured it would at least make sense to mirror how Node chooses between these two functions.

When `domain` is required [it sets up domain use](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/lib/domain.js#L36) which [changes the `tick_callback_function`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/src/node.cc#L1069) in the `Environment` and also [adds a `domain` property to `process`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/lib/domain.js#L20). So at the very least, I think it makes sense to invoke the callback that Node would be invoking once no longer in a nested `AsyncCallbackScope`.

While this doesn't really change much today since [`_tickCallback`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/lib/internal/process/next_tick.js#L87) and [`_tickDomainCallback`](https://github.com/nodejs/node/blob/828f0c838e81096b9debd6e7f55e54b556eb7ef8/lib/internal/process/next_tick.js#L108) functions are nearly identical (and the domain version is graceful with the absence of a `domain`), it does better future-proof the code a little (especially since domains are deprecated).