### PR TITLE
Update build.js to support s390x

### DIFF
--- a/build.js
+++ b/build.js
@@ -31,7 +31,8 @@ if (!{
 		arm: true,
 		arm64: true,
 		ppc64: true,
-		ppc: true
+		ppc: true,
+		s390x: true
 	}.hasOwnProperty(arch)) {
 	console.error('Unsupported (?) architecture: `' + arch + '`');
 	process.exit(1);


### PR DESCRIPTION
I needed to use deasync on a project we're running on the mainframe (s390x). I was able to use the deasync package successfully on an Ubuntu s390x 16.04 build using Docker container s390x/ubuntu.

I was also able to run it using s390x/ibmnode, which is built off of the Ubuntu base image. 

I don't think there will be any issues with this running on s390x, all the required libs are there across the multiple distributions. 