### PR TITLE
Add test that can be automatically verified and test entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "install": "node ./build.js"
+    "install": "node ./build.js",
+    "test": "node test.js"
   },
   "dependencies": {
     "bindings": "~1.2.1",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var deasync = require('./index.js');
 var cp = require('child_process');
 var http = require('http');
+const assert = require("assert");
 
 var exec = deasync(cp.exec);
 
@@ -25,6 +26,13 @@ var request = deasync(function (url, done) {
 setTimeout(function () {
   console.log('async');
 }, 1000);
+
+var response = 42;
+var test = deasync(function(done) {
+  done(null, response);
+});
+var result = test();
+assert(result === response);
 
 console.log(exec('ls -la'));
 sleep(2000);


### PR DESCRIPTION
Allow module to be tested with ```npm test```.

Add test that is verified with an assert so that it doesn't require manually reading the output.