### PR TITLE
build.js: fix LoongArch platform ARCH for loong64

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,7 +32,7 @@ if (
     ppc: true,
     s390x: true,
     mips64el: true,
-    loongarch64: true,
+    loong64: true,
   }.hasOwnProperty(arch)
 ) {
   console.error('Unsupported (?) architecture: `' + arch + '`');


### PR DESCRIPTION

Hi,
LoongArch V8 ARCH uses loong64，v8 had been add loong64 backend, LoongArch Nodejs os.arch() outputs loong64.
so ARCH should use loong64 here

[Nodejs loong64 base support patches](https://github.com/nodejs/node/pull/41323)

thx~